### PR TITLE
Save, get, and delete using localStorage fallback

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
+    "moment": "^2.14.0",
     "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0"
   },
   "devDependencies": {

--- a/rise-data.html
+++ b/rise-data.html
@@ -2,6 +2,8 @@
 <link rel="import" href="../iron-ajax/iron-ajax.html">
 <link rel="import" href="../rise-logger/rise-logger.html">
 
+<script src="../moment/moment.js"></script>
+
 <!--
 `rise-data` is a web component for storing data.
 
@@ -28,14 +30,20 @@
 
 <script>
   (function() {
-    /* global Polymer */
+    /* global Polymer, moment */
     /* jshint newcap: false */
 
     "use strict";
 
     var BQ_TABLE_NAME = "component_data_events";
 
-    var BASE_CACHE_URL = "//localhost:9494";
+    function supportsLocalStorage() {
+      try {
+        return "localStorage" in window && window.localStorage !== null;
+      } catch (e) {
+        return false;
+      }
+    }
 
     Polymer({
       is: "rise-data",
@@ -74,11 +82,9 @@
       /**
        * Fires when an error is received from the ping request.
        */
-      _handlePingError: function(e, resp) {
+      _handlePingError: function() {
         this._isCacheRunning = false;
         this._pingReceived = true;
-
-        console.log("[rise-data] Ping Error");
       },
 
       /**
@@ -105,6 +111,83 @@
 
         // log usage
         this.$.logger.log(BQ_TABLE_NAME, params);
+      },
+
+      /**
+       * Cache the data
+       *
+       * @param {String} key The key to identify the item of data
+       * @param {Object} data The data to cache
+       * @param {Boolean} ts Optionally include a timestamp to cache
+       */
+      saveItem: function(key, data, ts) {
+        var cacheObj = {};
+
+        if (this._pingReceived && key && data) {
+          if (!this._isCacheRunning) {
+            if (supportsLocalStorage()) {
+              cacheObj.data = data;
+
+              if (ts) {
+                cacheObj.timestamp = moment().format();
+              }
+
+              try {
+                localStorage.setItem(key, JSON.stringify(cacheObj));
+              } catch(e) {
+                console.warn(e.message);
+              }
+
+            }
+          }
+
+          // TODO: handle Rise Cache running
+        }
+      },
+
+      /**
+       * Retrieve the data
+       *
+       * @param {String} key The key to identify the item of data
+       * @return {Object} The cached data.
+       */
+      getItem: function(key) {
+        var data = null;
+
+        if (this._pingReceived && key) {
+          if (!this._isCacheRunning) {
+            if (supportsLocalStorage()) {
+              // retrieve cached data and parse back
+              data = JSON.parse(localStorage.getItem(key));
+            }
+          }
+
+          // TODO: handle Rise Cache running
+        }
+
+        return data;
+
+      },
+
+      /**
+       * Delete the data
+       *
+       * @param {String} key The key to identify the item of data
+       */
+      deleteItem: function(key) {
+        if (this._pingReceived && key) {
+          if (!this._isCacheRunning) {
+            if (supportsLocalStorage()) {
+              try {
+                localStorage.removeItem(key);
+              } catch (ex) {
+                console.warn(ex.message);
+              }
+            }
+          }
+
+          // TODO: handle Rise Cache running
+        }
       }
 
     });

--- a/test/data/sheet.js
+++ b/test/data/sheet.js
@@ -1,0 +1,12 @@
+var sheetData = {
+  "majorDimension": "ROWS",
+  "range": "Sheet1!A1:F999",
+  "values": [
+    ["Name", "Type", "Total"],
+    ["Apple", "Fruit", "0.99"],
+    ["Milk", "Drink", "3.99"],
+    ["Crackers", "Snack", "5.99"]
+  ]
+};
+
+var sheetKey = "risesheet_abc";

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,8 @@
 <body>
 <script>
   WCT.loadSuites([
-    // TODO: tests to come
+    "unit/rise-data.html",
+    "unit/rise-data-local-storage.html"
   ]);
 </script>
 </body>

--- a/test/unit/rise-data-local-storage.html
+++ b/test/unit/rise-data-local-storage.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-data</title>
+
+  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../rise-data.html">
+</head>
+<body>
+
+<rise-data id="request"></rise-data>
+
+<script src="../data/sheet.js"></script>
+<script src="../../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
+
+<script>
+
+  var dataRequest = document.querySelector("#request");
+
+  // mock logger getting display id and force handler RC not running
+  sinon.stub(dataRequest.$.logger.$.displayId, "generateRequest", function() {
+    dataRequest.$.logger._onDisplayIdError();
+  });
+
+  // mock ping and force handler of RC not running
+  sinon.stub(dataRequest.$.ping, "generateRequest", function() {
+    dataRequest._handlePingError();
+  });
+
+  suite("localStorage", function () {
+
+    suite("saveItem", function () {
+
+      teardown(function () {
+        window.localStorageError = false;
+        localStorage.removeItem(sheetKey);
+      });
+
+      test("should catch error thrown by localStorage.setItem and log a warning in console", function () {
+        var warnSpy = sinon.spy(console, "warn");
+
+        // force an error from localStorage.setItem()
+        window.localStorageError = true;
+
+        dataRequest.saveItem(sheetKey, {results: sheetData.values});
+
+        assert(warnSpy.calledOnce);
+        console.warn.restore();
+      });
+
+      test("should ensure data passed in localStorage.setItem() is stringified", function () {
+        dataRequest.saveItem(sheetKey, {results: sheetData.values});
+
+        var value = localStorage.getItem(sheetKey);
+
+        assert.isString(value);
+      });
+
+      test("should ensure timestamp is added to cached data", function () {
+        dataRequest.saveItem(sheetKey, {results: sheetData.values}, true);
+
+        var value = localStorage.getItem(sheetKey);
+
+        assert.property(JSON.parse(value), "timestamp");
+        assert.isString(JSON.parse(value).timestamp, "timestamp");
+      });
+
+    });
+
+    suite("getItem", function () {
+      var value;
+
+      teardown(function () {
+        localStorage.removeItem(sheetKey);
+      });
+
+      test("Should return null when no cached data exists", function () {
+        value = dataRequest.getItem(sheetKey);
+
+        assert.isNull(value);
+      });
+
+      test("Should return null when no key provided", function () {
+        value = dataRequest.getItem();
+
+        assert.isNull(value);
+      });
+
+      test("Should ensure value returned has been parsed as JSON", function () {
+        localStorage.setItem(sheetKey, JSON.stringify({data: {results: sheetData.values}, timestamp: ""}));
+
+        value = dataRequest.getItem(sheetKey);
+
+        assert.isObject(value);
+      });
+    });
+
+    suite("deleteItem", function () {
+      setup(function () {
+        localStorage.setItem(sheetKey, JSON.stringify({data: {results: sheetData.values}, timestamp: ""}));
+      });
+
+      teardown(function () {
+        localStorage.removeItem(sheetKey);
+      });
+
+      test("Should not delete data when no key provided", function () {
+        dataRequest.deleteItem();
+
+        assert.deepEqual(JSON.parse(localStorage.getItem(sheetKey)), {data: {results: sheetData.values}, timestamp: ""});
+      });
+
+      test("Should ensure data is removed", function () {
+        dataRequest.deleteItem(sheetKey);
+
+        assert.isNull(localStorage.getItem(sheetKey));
+      });
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/test/unit/rise-data.html
+++ b/test/unit/rise-data.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-data</title>
+
+  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../rise-data.html">
+</head>
+<body>
+
+<rise-data id="request"></rise-data>
+
+<script src="../data/sheet.js"></script>
+<script src="../../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
+
+<script>
+
+  var dataRequest = document.querySelector("#request");
+
+  // mock logger getting display id and force handler of RC not running
+  sinon.stub(dataRequest.$.logger.$.displayId, "generateRequest", function() {
+    dataRequest.$.logger._onDisplayIdError();
+  });
+
+  // mock ping and force handler of RC not running
+  sinon.stub(dataRequest.$.ping, "generateRequest", function() {
+    dataRequest._handlePingError();
+  });
+
+  suite("rise-data", function () {
+
+    suite("_isValidUsage", function () {
+
+      test("should return true when 'standalone' or 'widget'", function () {
+        assert.isTrue(dataRequest._isValidUsage("widget"));
+        assert.isTrue(dataRequest._isValidUsage("standalone"));
+      });
+
+      test("should return false when invalid", function () {
+        assert.isFalse(dataRequest._isValidUsage("test"));
+      });
+
+    });
+
+    suite("ready", function() {
+      var logStub;
+
+      setup(function() {
+        logStub = sinon.stub(dataRequest.$.logger, "log");
+      });
+
+      teardown(function() {
+        logStub.restore();
+        dataRequest.usage = "";
+      });
+
+      test("should log usage", function () {
+        dataRequest.ready();
+        assert.equal(logStub.args[0][0],"component_data_events");
+        assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"ready\",\"version\":");
+      });
+
+      test("should log usage and include 'usage_type'", function() {
+        dataRequest.usage = "widget";
+        dataRequest.ready();
+        assert.equal(logStub.args[0][0],"component_data_events");
+        assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"ready\",\"usage_type\":\"widget\",\"version\":");
+      });
+    });
+
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
- Functions `saveItem`, `getItem`, and `deleteItem` added which don't execute if RC ping not received or `key` param not provided
- Using `localStorage` as fallback to Rise Cache not running
- Added unit tests
