### PR TITLE
Save, get, and delete using Rise Cache

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
     "moment": "^2.14.0",
-    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0"
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0",
+    "underscore": "~1.8.2"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/rise-data.html
+++ b/rise-data.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../rise-logger/rise-logger.html">
 
 <script src="../moment/moment.js"></script>
+<script src="../underscore/underscore.js"></script>
 
 <!--
 `rise-data` is a web component for storing data.
@@ -20,6 +21,13 @@
                verbose="true">
     </iron-ajax>
 
+    <iron-ajax id="cache"
+               content-type="application/json"
+               handle-as="json"
+               on-response="_handleCacheResponse"
+               on-error="_handleCacheError">
+    </iron-ajax>
+
     <content></content>
   </template>
 </dom-module>
@@ -30,12 +38,14 @@
 
 <script>
   (function() {
-    /* global Polymer, moment */
+    /* global Polymer, moment, _ */
     /* jshint newcap: false */
 
     "use strict";
 
     var BQ_TABLE_NAME = "component_data_events";
+
+    var BASE_CACHE_URL = "//localhost:9494";
 
     function supportsLocalStorage() {
       try {
@@ -53,6 +63,11 @@
       },
 
       properties: {
+        endpoint: {
+          type: String,
+          value: ""
+        },
+
         /**
          * The optional usage type for Rise Vision logging purposes. Options are "standalone" or "widget"
          */
@@ -67,24 +82,127 @@
 
       _pingReceived: false,
 
+      _keys: [],
+
+      _currentKey: null,
+
+      _callback: null,
+
       _isValidUsage: function(usage) {
         return usage === "standalone" || usage === "widget";
       },
 
-      /**
-       * Fires when a response is received from the ping request.
-       */
+      _getCacheUrl: function(key) {
+        var url = BASE_CACHE_URL + "/" + this.endpoint;
+
+        if (this.$.cache.method === "PUT" || this.$.cache.method === "DELETE" || this.$.cache.method === "GET") {
+          url += "/" + key;
+        }
+
+        return url;
+      },
+
+      _getCacheBody: function(key, data) {
+        var body = {};
+
+        if (this.$.cache.method === "POST" || this.$.cache.method === "PUT") {
+          body.key = key;
+          body.value = data;
+        }
+
+        return body;
+      },
+
+      _handleCacheError: function(e, resp) {
+        var params = {
+          event: "error"
+        };
+
+        if (this.$.cache.method === "GET" && this._callback && typeof this._callback === "function") {
+          this._callback(null);
+          this._callback = null;
+
+          // don't continue with logging if 404
+          if (resp.request.status === 404) {
+            return;
+          }
+        }
+
+        if (resp.error) {
+          params.event_details = "[" + this.endpoint + "] " + resp.error.message;
+        }
+
+        // only include usage_type if it's a valid usage value
+        if (this._isValidUsage(this.usage)) {
+          params.usage_type = this.usage;
+        }
+
+        params.version = dataVersion;
+
+        // log usage
+        this.$.logger.log(BQ_TABLE_NAME, params);
+      },
+
+      _handleCacheResponse: function(e, resp) {
+        if (this._callback && typeof this._callback === "function") {
+          if (resp && resp.response) {
+            this._callback(resp.response);
+          }
+          else {
+            this._callback(null);
+          }
+        }
+
+        if (this.$.cache.method === "POST") {
+          this._keys.push(this._currentKey);
+        }
+        else if (this.$.cache.method === "DELETE") {
+          this._keys = _.without(this._keys, this._currentKey);
+        }
+
+        // reset callback value
+        this._callback = null;
+
+      },
+
       _handlePingResponse: function(e, resp) {
         this._isCacheRunning = resp.response && resp.response !== "";
         this._pingReceived = true;
       },
 
-      /**
-       * Fires when an error is received from the ping request.
-       */
       _handlePingError: function() {
         this._isCacheRunning = false;
         this._pingReceived = true;
+      },
+
+      _get: function(key, cb) {
+        this._currentKey = key;
+
+        this.$.cache.method = "GET";
+        this.$.cache.url = this._getCacheUrl(key);
+        this.$.cache.body = this._getCacheBody(key);
+
+        this._callback = cb;
+        this.$.cache.generateRequest();
+      },
+
+      _delete: function(key) {
+        this._currentKey = key;
+
+        this.$.cache.method = "DELETE";
+        this.$.cache.url = this._getCacheUrl(key);
+        this.$.cache.body = this._getCacheBody(key);
+        this.$.cache.generateRequest();
+      },
+
+      _save: function(key, data) {
+        this._currentKey = key;
+
+        this.$.cache.method = (_.indexOf(this._keys, key) !== -1) ? "PUT" : "POST";
+        this.$.cache.url = this._getCacheUrl(key);
+        this.$.cache.body = this._getCacheBody(key, data);
+
+        this.$.cache.generateRequest();
       },
 
       /**
@@ -135,13 +253,16 @@
               try {
                 localStorage.setItem(key, JSON.stringify(cacheObj));
               } catch(e) {
-                console.warn(e.message);
+                // TODO: use logger to log failure?
               }
 
             }
           }
-
-          // TODO: handle Rise Cache running
+          else {
+            if (this.endpoint) {
+              this._save(key, data);
+            }
+          }
         }
       },
 
@@ -149,23 +270,27 @@
        * Retrieve the data
        *
        * @param {String} key The key to identify the item of data
-       * @return {Object} The cached data.
+       * @param {Function} cb The callback to execute with provided data
        */
-      getItem: function(key) {
+      getItem: function(key, cb) {
         var data = null;
 
-        if (this._pingReceived && key) {
+        if (this._pingReceived && key && cb && typeof cb ==="function") {
           if (!this._isCacheRunning) {
             if (supportsLocalStorage()) {
               // retrieve cached data and parse back
               data = JSON.parse(localStorage.getItem(key));
+
+              cb(data);
+            }
+          }
+          else {
+            if (this.endpoint) {
+              this._get(key, cb);
             }
           }
 
-          // TODO: handle Rise Cache running
         }
-
-        return data;
 
       },
 
@@ -181,12 +306,15 @@
               try {
                 localStorage.removeItem(key);
               } catch (ex) {
-                console.warn(ex.message);
+                // TODO: use logger to log failure?
               }
             }
           }
-
-          // TODO: handle Rise Cache running
+          else {
+            if (this.endpoint) {
+              this._delete(key);
+            }
+          }
         }
       }
 

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,8 @@
 <script>
   WCT.loadSuites([
     "unit/rise-data.html",
-    "unit/rise-data-local-storage.html"
+    "unit/rise-data-local-storage.html",
+    "unit/rise-data-cache.html"
   ]);
 </script>
 </body>

--- a/test/unit/rise-data-cache.html
+++ b/test/unit/rise-data-cache.html
@@ -1,0 +1,473 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-data</title>
+
+  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../rise-data.html">
+</head>
+<body>
+
+<rise-data id="request"></rise-data>
+
+<script src="../data/sheet.js"></script>
+<script src="../../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
+
+<script>
+
+  var dataRequest = document.querySelector("#request");
+
+  // mock logger getting display id and force RC running
+  sinon.stub(dataRequest.$.logger.$.displayId, "generateRequest", function() {
+    dataRequest.$.logger._onDisplayIdResponse(null, {response: {displayId: "abc123"}});
+  });
+
+  // mock ping and force RC running
+  sinon.stub(dataRequest.$.ping, "generateRequest", function() {
+    dataRequest._handlePingResponse(null, {response:{ name : "rise-cache-v2", version: "0.0.0" }});
+  });
+
+  suite("rise cache", function () {
+
+    suite("_getCacheUrl", function() {
+
+      suiteSetup(function() {
+        dataRequest.endpoint = "spreadsheets"
+      });
+
+      suiteTeardown(function() {
+        dataRequest.endpoint = "";
+      });
+
+      teardown(function() {
+        dataRequest.$.cache.method = "";
+      });
+
+      test("should return correct URL when request method is POST", function() {
+        dataRequest.$.cache.method = "POST";
+        assert.equal(dataRequest._getCacheUrl(sheetKey), "//localhost:9494/spreadsheets");
+      });
+
+      test("should return correct URL when request method is GET", function() {
+        dataRequest.$.cache.method = "GET";
+        assert.equal(dataRequest._getCacheUrl(sheetKey), "//localhost:9494/spreadsheets/" + sheetKey);
+      });
+
+      test("should return correct URL when request method is PUT", function() {
+        dataRequest.$.cache.method = "PUT";
+        assert.equal(dataRequest._getCacheUrl(sheetKey), "//localhost:9494/spreadsheets/" + sheetKey);
+      });
+
+      test("should return correct URL when request method is DELETE", function() {
+        dataRequest.$.cache.method = "DELETE";
+        assert.equal(dataRequest._getCacheUrl(sheetKey), "//localhost:9494/spreadsheets/" + sheetKey);
+      });
+
+    });
+
+    suite("_getCacheBody", function() {
+
+      teardown(function() {
+        dataRequest.$.cache.method = "";
+      });
+
+      test("should return empty object when request method is GET", function() {
+        dataRequest.$.cache.method = "GET";
+        assert.deepEqual(dataRequest._getCacheBody(sheetKey, sheetData.values), {});
+      });
+
+      test("should return empty object when request method is DELETE", function() {
+        dataRequest.$.cache.method = "DELETE";
+        assert.deepEqual(dataRequest._getCacheBody(sheetKey, sheetData.values), {});
+      });
+
+      test("should return body object value when request is a POST", function() {
+        dataRequest.$.cache.method = "POST";
+
+        assert.deepEqual(dataRequest._getCacheBody(sheetKey, sheetData.values), {
+          key: sheetKey,
+          value: sheetData.values
+        });
+      });
+
+      test("should return body object value when request is a PUT", function() {
+        dataRequest.$.cache.method = "PUT";
+
+        assert.deepEqual(dataRequest._getCacheBody(sheetKey, sheetData.values), {
+          key: sheetKey,
+          value: sheetData.values
+        });
+      });
+
+    });
+
+    suite("_handleCacheError", function() {
+
+      var resp = {
+        request: {
+          status: 404
+        },
+        error: {
+          message: "The request failed with status: 404"
+        }
+      },
+        logStub;
+
+      setup(function() {
+        dataRequest.endpoint = "spreadsheets";
+        logStub = sinon.stub(dataRequest.$.logger, "log");
+      });
+
+      teardown(function () {
+        dataRequest._callback = null;
+        dataRequest.$.cache.method = "";
+        dataRequest._currentKey = "";
+        dataRequest._keys = [];
+        dataRequest.endpoint = "";
+        logStub.restore();
+      });
+
+      test("should execute callback when request method was GET", function() {
+        var spy;
+
+        dataRequest._callback = function(){};
+        dataRequest.$.cache.method = "GET";
+
+        spy = sinon.spy(dataRequest, "_callback");
+
+        dataRequest._handleCacheError(null, resp);
+
+        assert.isTrue(spy.calledOnce);
+      });
+
+      test("should reset callback value when request method was GET", function() {
+        dataRequest._callback = function(){};
+        dataRequest.$.cache.method = "GET";
+        dataRequest._handleCacheError(null, resp);
+
+        assert.isNull(dataRequest._callback);
+      });
+
+      test("should not log if request method was GET and error status code was 404", function () {
+        dataRequest._callback = function(){};
+        dataRequest.$.cache.method = "GET";
+        dataRequest._handleCacheError(null, resp);
+
+        assert.equal(logStub.callCount, 0);
+      });
+
+      test("should log error details", function () {
+        var resp = {
+          request: {
+            status: 500
+          },
+          error: {
+            message: "The request failed with status: 500"
+          }
+        };
+
+        dataRequest._handleCacheError(null, resp);
+
+        assert.equal(logStub.args[0][0], "component_data_events");
+        assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"error\",\"event_details\":\"[spreadsheets] The request failed with status: 500\",\"version\":");
+      });
+
+    });
+
+    suite("_handleCacheResponse", function() {
+
+      var resp = {response: {results: sheetData.values}};
+
+      teardown(function () {
+        dataRequest._callback = null;
+        dataRequest.$.cache.method = "";
+        dataRequest._currentKey = "";
+        dataRequest._keys = [];
+      });
+
+      test("should execute callback", function() {
+        var spy;
+
+        dataRequest._callback = function(){};
+
+        spy = sinon.spy(dataRequest, "_callback");
+
+        dataRequest._handleCacheResponse(null, resp);
+
+        assert.isTrue(spy.calledOnce);
+      });
+
+      test("should add key to list when request was POST", function() {
+        dataRequest.$.cache.method = "POST";
+        dataRequest._currentKey = sheetKey;
+        dataRequest._handleCacheResponse(null, resp);
+
+        assert.deepEqual(dataRequest._keys, [sheetKey]);
+      });
+
+      test("should delete key from list when request was DELETE", function() {
+        dataRequest.$.cache.method = "DELETE";
+        dataRequest._currentKey = sheetKey;
+        dataRequest._keys = [sheetKey];
+        dataRequest._handleCacheResponse(null, resp);
+
+        assert.deepEqual(dataRequest._keys, []);
+      });
+
+      test("should reset callback value", function() {
+        dataRequest._callback = function(){};
+        dataRequest._handleCacheResponse(null, resp);
+
+        assert.isNull(dataRequest._callback);
+      });
+
+    });
+
+    suite("_get", function () {
+      var requestStub;
+
+      setup(function () {
+        requestStub = sinon.stub(dataRequest.$.cache, "generateRequest");
+      });
+
+      teardown(function () {
+        requestStub.restore();
+        dataRequest._keys = [];
+        dataRequest._currentKey = null;
+        dataRequest._callback = null;
+        dataRequest.endpoint = "";
+      });
+
+      test("should set current key", function() {
+        dataRequest._get(sheetKey, function(){});
+
+        assert.equal(dataRequest._currentKey, sheetKey);
+      });
+
+      test("should set callback", function() {
+        dataRequest._get(sheetKey, function(){});
+
+        assert.isFunction(dataRequest._callback);
+      });
+
+      test("should set request method to 'GET'", function () {
+        dataRequest._get(sheetKey, function(){});
+
+        assert.equal(dataRequest.$.cache.method, "GET");
+      });
+
+      test("should generate request to Rise Cache", function() {
+        dataRequest.endpoint = "spreadsheets";
+        dataRequest._get(sheetKey, function(){});
+
+        assert.isTrue(requestStub.calledOnce);
+      })
+    });
+
+    suite("_delete", function () {
+      var requestStub;
+
+      setup(function () {
+        requestStub = sinon.stub(dataRequest.$.cache, "generateRequest");
+      });
+
+      teardown(function () {
+        requestStub.restore();
+        dataRequest._keys = [];
+        dataRequest._currentKey = null;
+        dataRequest.endpoint = "";
+      });
+
+      test("should set current key", function() {
+        dataRequest._delete(sheetKey);
+
+        assert.equal(dataRequest._currentKey, sheetKey);
+      });
+
+      test("should set request method to 'DELETE'", function () {
+        dataRequest._delete(sheetKey);
+
+        assert.equal(dataRequest.$.cache.method, "DELETE");
+      });
+
+      test("should generate request to Rise Cache", function() {
+        dataRequest.endpoint = "spreadsheets";
+        dataRequest._delete(sheetKey);
+
+        assert.isTrue(requestStub.calledOnce);
+      })
+    });
+
+    suite("_save", function () {
+      var requestStub;
+
+      setup(function () {
+        requestStub = sinon.stub(dataRequest.$.cache, "generateRequest");
+      });
+
+      teardown(function () {
+        requestStub.restore();
+        dataRequest._keys = [];
+        dataRequest._currentKey = null;
+        dataRequest.endpoint = "";
+      });
+
+      test("should set current key", function() {
+        dataRequest._save(sheetKey, {results: sheetData.values});
+
+        assert.equal(dataRequest._currentKey, sheetKey);
+      });
+
+      test("should set request method to 'POST'", function () {
+        dataRequest._save(sheetKey, {results: sheetData.values});
+
+        assert.equal(dataRequest.$.cache.method, "POST");
+      });
+
+      test("should set request method to 'PUT'", function () {
+        dataRequest._keys = [sheetKey];
+        dataRequest._save(sheetKey, {results: sheetData.values});
+
+        assert.equal(dataRequest.$.cache.method, "PUT");
+      });
+
+      test("should generate request to Rise Cache", function() {
+        dataRequest.endpoint = "spreadsheets";
+        dataRequest._save(sheetKey, {results: sheetData.values});
+
+        assert.isTrue(requestStub.calledOnce);
+      })
+    });
+
+    suite("saveItem", function () {
+      var saveStub;
+
+      setup(function () {
+        saveStub = sinon.stub(dataRequest, "_save");
+      });
+
+      teardown(function () {
+        saveStub.restore();
+      });
+
+      suiteTeardown(function () {
+        dataRequest.endpoint = "";
+      });
+
+      test("should not request to save without key param", function () {
+        dataRequest.saveItem(false, {results: sheetData.values});
+
+        assert.equal(saveStub.callCount, 0);
+      });
+
+      test("should not request to save without data param", function () {
+        dataRequest.saveItem(sheetKey);
+
+        assert.equal(saveStub.callCount, 0);
+      });
+
+      test("should not request to save without endpoint attribute being set", function () {
+        dataRequest.saveItem(sheetKey, {results: sheetData.values});
+
+        assert.equal(saveStub.callCount, 0);
+      });
+
+      test("should request to save", function () {
+        dataRequest.endpoint = "spreadsheets";
+        dataRequest.saveItem(sheetKey, {results: sheetData.values});
+
+        assert.isTrue(saveStub.calledOnce);
+      });
+
+    });
+
+    suite("getItem", function () {
+      var getStub;
+
+      setup(function () {
+        getStub = sinon.stub(dataRequest, "_get");
+      });
+
+      teardown(function () {
+        getStub.restore();
+      });
+
+      suiteTeardown(function () {
+        dataRequest.endpoint = "";
+      });
+
+      test("should not request to get without key param", function () {
+        dataRequest.getItem(false, function(){});
+
+        assert.equal(getStub.callCount, 0);
+      });
+
+      test("should not request to get data without callback function param", function () {
+        dataRequest.getItem(sheetKey);
+
+        assert.equal(getStub.callCount, 0);
+      });
+
+      test("should not request to get data if callback param not a function", function () {
+        dataRequest.getItem(sheetKey, "callback");
+
+        assert.equal(getStub.callCount, 0);
+      });
+
+      test("should not request to get data without endpoint attribute being set", function () {
+        dataRequest.getItem(sheetKey, {results: sheetData.values});
+
+        assert.equal(getStub.callCount, 0);
+      });
+
+      test("should request to get data", function () {
+        dataRequest.endpoint = "spreadsheets";
+        dataRequest.getItem(sheetKey, function(){});
+
+        assert.isTrue(getStub.calledOnce);
+      });
+    });
+
+    suite("deleteItem", function () {
+      var deleteStub;
+
+      setup(function () {
+        deleteStub = sinon.stub(dataRequest, "_delete");
+      });
+
+      teardown(function () {
+        deleteStub.restore();
+      });
+
+      suiteTeardown(function () {
+        dataRequest.endpoint = "";
+      });
+
+      test("should not request to delete without key param", function () {
+        dataRequest.deleteItem();
+
+        assert.equal(deleteStub.callCount, 0);
+      });
+
+      test("should not request to delete data without endpoint attribute being set", function () {
+        dataRequest.deleteItem(sheetKey);
+
+        assert.equal(deleteStub.callCount, 0);
+      });
+
+      test("should request to delete data", function () {
+        dataRequest.endpoint = "spreadsheets";
+        dataRequest.deleteItem(sheetKey);
+
+        assert.isTrue(deleteStub.calledOnce);
+      });
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/test/unit/rise-data-local-storage.html
+++ b/test/unit/rise-data-local-storage.html
@@ -40,18 +40,6 @@
         localStorage.removeItem(sheetKey);
       });
 
-      test("should catch error thrown by localStorage.setItem and log a warning in console", function () {
-        var warnSpy = sinon.spy(console, "warn");
-
-        // force an error from localStorage.setItem()
-        window.localStorageError = true;
-
-        dataRequest.saveItem(sheetKey, {results: sheetData.values});
-
-        assert(warnSpy.calledOnce);
-        console.warn.restore();
-      });
-
       test("should ensure data passed in localStorage.setItem() is stringified", function () {
         dataRequest.saveItem(sheetKey, {results: sheetData.values});
 
@@ -78,24 +66,30 @@
         localStorage.removeItem(sheetKey);
       });
 
-      test("Should return null when no cached data exists", function () {
-        value = dataRequest.getItem(sheetKey);
+      test("should not execute callback without key param", function() {
+        var spy = sinon.spy();
 
-        assert.isNull(value);
+        dataRequest.getItem(false, spy);
+
+        assert.equal(spy.callCount, 0);
       });
 
-      test("Should return null when no key provided", function () {
-        value = dataRequest.getItem();
+      test("should execute callback with null value when no data stored", function() {
+        var spy = sinon.spy();
 
-        assert.isNull(value);
+        dataRequest.getItem(sheetKey, spy);
+
+        assert.isTrue(spy.calledWith(null));
       });
 
-      test("Should ensure value returned has been parsed as JSON", function () {
+      test("should execute callback providing data", function() {
+        var spy = sinon.spy();
+
         localStorage.setItem(sheetKey, JSON.stringify({data: {results: sheetData.values}, timestamp: ""}));
 
-        value = dataRequest.getItem(sheetKey);
+        dataRequest.getItem(sheetKey, spy);
 
-        assert.isObject(value);
+        assert.isTrue(spy.calledWith({data: {results: sheetData.values}, timestamp: ""}));
       });
     });
 


### PR DESCRIPTION
- `getItem` requires a callback function
- Using RiseCache to POST, PUT, GET, and DELETE data
- Executing callback in RC response if it was a GET request
- Executing callback in RC error handler
- Logging error to BQ in RC error handler if status is not a `404`
- Unit tests revised and added
