### PR TITLE
Return `value` property of cache response

### DIFF
--- a/rise-data.html
+++ b/rise-data.html
@@ -145,7 +145,7 @@
       _handleCacheResponse: function(e, resp) {
         if (this._callback && typeof this._callback === "function") {
           if (resp && resp.response) {
-            this._callback(resp.response);
+            this._callback(resp.response.value);
           }
           else {
             this._callback(null);

--- a/test/unit/rise-data-cache.html
+++ b/test/unit/rise-data-cache.html
@@ -180,7 +180,14 @@
 
     suite("_handleCacheResponse", function() {
 
-      var resp = {response: {results: sheetData.values}};
+      var resp = {
+        response: {
+          key: sheetKey,
+          value: {
+            results: sheetData.values
+          }
+        }
+      };
 
       teardown(function () {
         dataRequest._callback = null;
@@ -189,7 +196,7 @@
         dataRequest._keys = [];
       });
 
-      test("should execute callback", function() {
+      test("should execute callback with correct data", function() {
         var spy;
 
         dataRequest._callback = function(){};
@@ -199,6 +206,7 @@
         dataRequest._handleCacheResponse(null, resp);
 
         assert.isTrue(spy.calledOnce);
+        assert.isTrue(spy.calledWith(resp.response.value));
       });
 
       test("should add key to list when request was POST", function() {


### PR DESCRIPTION
- To integrate with existing parent components, return the `value` property of Rise Cache GET response
- Added unit test
