### PR TITLE
Firing event when RC ping is received

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Web component for storing data",
   "scripts": {
     "test": "gulp test",

--- a/rise-data.html
+++ b/rise-data.html
@@ -32,7 +32,7 @@
 </dom-module>
 
 <!-- build:version -->
-<script>var dataVersion = "1.0.0";</script>
+<script>var dataVersion = "1.1.0";</script>
 <!-- endbuild -->
 
 <script>
@@ -86,6 +86,12 @@
       _currentKey: null,
 
       _callback: null,
+
+      /**
+       * Fired when a ping to Rise Cache has been received.
+       *
+       * @event rise-data-ping-received
+       */
 
       _isValidUsage: function(usage) {
         return usage === "standalone" || usage === "widget";
@@ -167,11 +173,15 @@
       _handlePingResponse: function(e, resp) {
         this._isCacheRunning = resp.response && resp.response !== "";
         this._pingReceived = true;
+
+        this.fire( "rise-data-ping-received", this._isCacheRunning );
       },
 
       _handlePingError: function() {
         this._isCacheRunning = false;
         this._pingReceived = true;
+
+        this.fire( "rise-data-ping-received", this._isCacheRunning );
       },
 
       _get: function(key, cb) {

--- a/test/unit/rise-data.html
+++ b/test/unit/rise-data.html
@@ -46,6 +46,42 @@
 
     });
 
+    suite( "_handlePingResponse", function() {
+
+      test( "should fire 'rise-data-ping-received'", function(done) {
+        var responseHandler = function (response) {
+          assert.isTrue(response.detail);
+
+          dataRequest.removeEventListener("rise-data-ping-received", responseHandler);
+
+          done();
+        };
+
+        dataRequest.addEventListener("rise-data-ping-received", responseHandler);
+
+        dataRequest._handlePingResponse( null, { response: { name: "rise-cache-v2", version: "0.0.0" } } );
+      } );
+
+    } );
+
+    suite( "_handlePingError", function() {
+
+      test( "should fire 'rise-data-ping-received'", function(done) {
+        var responseHandler = function (response) {
+          assert.isFalse(response.detail);
+
+          dataRequest.removeEventListener("rise-data-ping-received", responseHandler);
+
+          done();
+        };
+
+        dataRequest.addEventListener("rise-data-ping-received", responseHandler);
+
+        dataRequest._handlePingError();
+      } );
+
+    } );
+
     suite("ready", function() {
       var logStub;
 


### PR DESCRIPTION
- Firing `rise-data-ping-received` when RC ping response or error occurs and includes status of RC running
- Unit tests added
- Feature version bump