### PR TITLE
Fix/date parsing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "authors": [
     "Rise Vision"
   ],

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  node:
+    version: 6.6.0
 dependencies:
   pre:
     # latest stable chrome

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Web component for storing data",
   "scripts": {
     "test": "gulp test",

--- a/rise-data.html
+++ b/rise-data.html
@@ -32,7 +32,7 @@
 </dom-module>
 
 <!-- build:version -->
-<script>var dataVersion = "1.1.1";</script>
+<script>var dataVersion = "1.2.0";</script>
 <!-- endbuild -->
 
 <script>

--- a/rise-data.html
+++ b/rise-data.html
@@ -261,6 +261,25 @@
       },
 
       /**
+       * Retrieve the date strings as objects
+       *
+       * @param {String} key The key of the JS object
+       * @param {Object} value The value referring to the key
+       */
+      _dateReviver: function( key, value ) {
+        var a;
+
+        if ( typeof value === "string" ) {
+          a = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec( value );
+          if ( a ) {
+            return new Date( Date.UTC( +a[ 1 ], +a[ 2 ] - 1, +a[ 3 ], +a[ 4 ],
+              +a[ 5 ], +a[ 6 ] ) );
+          }
+        }
+        return value;
+      },
+
+      /**
        * Retrieve the data
        *
        * @param {String} key The key to identify the item of data
@@ -273,7 +292,7 @@
           if ( !this._isCacheRunning ) {
             if ( supportsLocalStorage() ) {
               // retrieve cached data and parse back
-              data = JSON.parse( localStorage.getItem( key ) );
+              data = JSON.parse( localStorage.getItem( key ), this._dateReviver );
 
               cb( data );
             }

--- a/test/data/sheet.js
+++ b/test/data/sheet.js
@@ -8,6 +8,7 @@ var sheetData = {
     [ "Apple", "Fruit", "0.99" ],
     [ "Milk", "Drink", "3.99" ],
     [ "Crackers", "Snack", "5.99" ]
-    ]
+    ],
+    "date": new Date( 2017, 1, 15, 0, 0, 0 )
   },
   sheetKey = "risesheet_abc";

--- a/test/unit/rise-data-local-storage.html
+++ b/test/unit/rise-data-local-storage.html
@@ -83,6 +83,16 @@
 
         assert.isTrue( spy.calledWith( { data: { results: sheetData.values }, timestamp: "" } ) );
       } );
+
+      test( "should return date object when a date string is saved", function() {
+        var spy = sinon.spy();
+
+        localStorage.setItem( sheetKey, JSON.stringify( { data: { results: sheetData.date }, timestamp: "" } ) );
+
+        dataRequest.getItem( sheetKey, spy );
+
+        assert.isTrue( spy.calledWith( { data: { results: sheetData.date }, timestamp: "" } ) );
+      } );
     } );
 
     suite( "deleteItem", function() {


### PR DESCRIPTION
@stulees I found the issue with the date format is caused by a non supported parsing by the JSON.parse( more about it in [here](http://stackoverflow.com/questions/15120256/json-parse-or-alternative-library-that-will-also-parse-dates/15120418#15120418)) .

I fixed that by adding a helper function to the JSON.parser which will parse date string from local storage to date object. 

I have also checked that the issue does not happen with Rise Cache.

Please review.

Cheers