### PR TITLE
Only use POST for method to save to RC

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Web component for storing data",
   "scripts": {
     "test": "gulp test",

--- a/rise-data.html
+++ b/rise-data.html
@@ -32,7 +32,7 @@
 </dom-module>
 
 <!-- build:version -->
-<script>var dataVersion = "1.3.8";</script>
+<script>var dataVersion = "1.3.9";</script>
 <!-- endbuild -->
 
 <script>
@@ -120,7 +120,7 @@
       _getCacheUrl: function( key, method ) {
         var url = this._baseCacheUrl + "/" + this.endpoint;
 
-        if ( method === "PUT" || method === "DELETE" || method === "GET" ) {
+        if ( method === "DELETE" || method === "GET" ) {
           url += "/" + key;
         }
 
@@ -130,7 +130,7 @@
       _getCacheBody: function( key, data, method ) {
         var body = {};
 
-        if ( method === "POST" || method === "PUT" ) {
+        if ( method === "POST" ) {
           body.key = key;
           body.value = data;
         }
@@ -345,7 +345,7 @@
       },
 
       _save: function( key, data ) {
-        var method = ( _.indexOf( this._keys, key ) !== -1 ) ? "PUT" : "POST",
+        var method = "POST",
           url = this._getCacheUrl( key, method ),
           body = JSON.stringify( this._getCacheBody( key, data, method ) );
 

--- a/test/unit/rise-data-cache.html
+++ b/test/unit/rise-data-cache.html
@@ -59,11 +59,6 @@
         assert.equal( dataRequest._getCacheUrl( sheetKey, "GET" ), "https://localhost:9494/spreadsheets/" + sheetKey );
       } );
 
-      test( "should return correct URL when request method is PUT", function() {
-        dataRequest.$.cache.method = "PUT";
-        assert.equal( dataRequest._getCacheUrl( sheetKey, "PUT" ), "https://localhost:9494/spreadsheets/" + sheetKey );
-      } );
-
       test( "should return correct URL when request method is DELETE", function() {
         dataRequest.$.cache.method = "DELETE";
         assert.equal( dataRequest._getCacheUrl( sheetKey, "DELETE" ), "https://localhost:9494/spreadsheets/" + sheetKey );
@@ -91,15 +86,6 @@
         dataRequest.$.cache.method = "POST";
 
         assert.deepEqual( dataRequest._getCacheBody( sheetKey, sheetData.values, "POST" ), {
-          key: sheetKey,
-          value: sheetData.values
-        } );
-      } );
-
-      test( "should return body object value when request is a PUT", function() {
-        dataRequest.$.cache.method = "PUT";
-
-        assert.deepEqual( dataRequest._getCacheBody( sheetKey, sheetData.values, "PUT" ), {
           key: sheetKey,
           value: sheetData.values
         } );
@@ -405,11 +391,11 @@
         assert.equal( dataRequest.$.cache.method, "POST" );
       } );
 
-      test( "should set request method to 'PUT'", function() {
+      test( "should set request method to 'POST' when performing update operation", function() {
         dataRequest._keys = [ sheetKey ];
         dataRequest._save( sheetKey, { results: sheetData.values } );
 
-        assert.equal( dataRequest.$.cache.method, "PUT" );
+        assert.equal( dataRequest.$.cache.method, "POST" );
       } );
 
       test( "should generate request to Rise Cache", function() {
@@ -444,25 +430,6 @@
         dataRequest._isRiseCacheSchemeEnabled.restore();
       } );
 
-      test( "should use Fetch to PUT request to Rise Cache", function() {
-        var fetchStub = sinon.stub( dataRequest, "_fetch" );
-
-        sinon.stub( dataRequest, "_isRiseCacheSchemeEnabled", function() {
-          return true;
-        } );
-
-        dataRequest.endpoint = "spreadsheets";
-        dataRequest._keys = [ sheetKey ];
-        dataRequest._save( sheetKey, { results: sheetData.values } );
-
-        assert.equal( requestStub.callCount, 0 );
-
-        assert.equal( fetchStub.args[ 0 ][ 0 ], "PUT" );
-        assert.include( fetchStub.args[ 0 ][ 1 ], "/spreadsheets/risesheet_abc" );
-
-        dataRequest._fetch.restore();
-        dataRequest._isRiseCacheSchemeEnabled.restore();
-      } );
     } );
 
     suite( "saveItem", function() {


### PR DESCRIPTION
- Electron has an issue when it sends redirect request via custom scheme protocol handling and the method is PUT. Working around this by always using POST.