### PR TITLE
Leverage "ready" hook instead of "attached"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "authors": [
     "Rise Vision"
   ],
@@ -21,7 +21,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
-    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.11",
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.12",
     "underscore": "~1.8.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "gulp-html-replace": "~1.6.1",
     "run-sequence": "~1.1.0",
     "web-component-tester": "^6.0.0",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#v1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Web component for storing data",
   "scripts": {
     "test": "gulp test",

--- a/rise-data.html
+++ b/rise-data.html
@@ -32,7 +32,7 @@
 </dom-module>
 
 <!-- build:version -->
-<script>var dataVersion = "2.0.1";</script>
+<script>var dataVersion = "2.0.2";</script>
 <!-- endbuild -->
 
 <script>
@@ -369,22 +369,13 @@
       },
 
       /**
-       * An instance of the element was inserted into the DOM.
-       */
-      attached: function() {
-        var protocol = ( this._isRiseCacheSchemeEnabled() ) ? "rchttps://" : "https://";
-
-        this._baseCacheUrl = protocol + "localhost:9495";
-        this.$.ping.generateRequest();
-      },
-
-      /**
        * Polymer has finished its initialization. This is the entry point.
        */
       ready: function() {
         var params = {
-          event: "ready"
-        };
+            event: "ready"
+          },
+          protocol = ( this._isRiseCacheSchemeEnabled() ) ? "rchttps://" : "https://";
 
         // only include usage_type if it's a valid usage value
         if ( this._isValidUsage( this.usage ) ) {
@@ -392,6 +383,10 @@
         }
 
         params.version = dataVersion;
+
+        // ping rise cache
+        this._baseCacheUrl = protocol + "localhost:9495";
+        this.$.ping.generateRequest();
 
         // log usage
         this.$.logger.log( BQ_TABLE_NAME, params );

--- a/rise-data.html
+++ b/rise-data.html
@@ -368,14 +368,28 @@
         }
       },
 
+      _startTests: function() {
+        // ensure to not execute code below if this integration test flag is not set
+        if ( !window.riseLoggerTests ) {
+          return;
+        }
+
+        this.ready( true );
+      },
+
       /**
        * Polymer has finished its initialization. This is the entry point.
        */
-      ready: function() {
+      ready: function( runningTests ) {
         var params = {
             event: "ready"
           },
           protocol = ( this._isRiseCacheSchemeEnabled() ) ? "rchttps://" : "https://";
+
+        // Necessary for integration tests so this function doesn't execute code below before stubs can be created
+        if ( window.riseLoggerTests && !runningTests ) {
+          return;
+        }
 
         // only include usage_type if it's a valid usage value
         if ( this._isValidUsage( this.usage ) ) {

--- a/test/unit/rise-data-cache.html
+++ b/test/unit/rise-data-cache.html
@@ -7,6 +7,10 @@
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script>
+    // global flag that rise-logger checks on ready handler for determining if running in an integration test
+    window.riseLoggerTests = true;
+  </script>
 
   <link rel="import" href="../../rise-data.html">
 </head>
@@ -20,7 +24,7 @@
 <script>
   /* global sinon, suite, test, assert, setup, teardown, suiteSetup, suiteTeardown, sheetKey, sheetData */
 
-  var dataRequest = document.querySelector( "#request" );
+  var dataRequest = document.querySelector( "#request" ); // eslint-disable-line vars-on-top
 
   // mock logger getting display id and force RC running
   sinon.stub( dataRequest.$.logger.$.displayId, "generateRequest", function() {
@@ -33,6 +37,11 @@
   } );
 
   suite( "rise cache", function() {
+
+    suiteSetup( function() {
+      // required for integration test
+      dataRequest._startTests();
+    } );
 
     suite( "_getCacheUrl", function() {
 

--- a/test/unit/rise-data-local-storage-rc-running.html
+++ b/test/unit/rise-data-local-storage-rc-running.html
@@ -7,6 +7,10 @@
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script>
+    // global flag that rise-logger checks on ready handler for determining if running in an integration test
+    window.riseLoggerTests = true;
+  </script>
 
   <link rel="import" href="../../rise-data.html">
 </head>
@@ -20,7 +24,7 @@
 <script>
   /* global sinon, suite, test, assert, suiteSetup, suiteTeardown, setup, teardown, sheetKey, sheetData */
 
-  var dataRequest = document.querySelector( "#request" );
+  var dataRequest = document.querySelector( "#request" ); // eslint-disable-line vars-on-top
 
   // mock logger getting display id and force RC running
   sinon.stub( dataRequest.$.logger.$.displayId, "generateRequest", function() {
@@ -35,6 +39,8 @@
   suite( "localStorage when RC is running", function() {
     suiteSetup( function() {
       dataRequest.endpoint = "spreadsheets"
+      // required for integration test
+      dataRequest._startTests();
     } );
 
     suiteTeardown( function() {

--- a/test/unit/rise-data-local-storage.html
+++ b/test/unit/rise-data-local-storage.html
@@ -7,6 +7,10 @@
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script>
+    // global flag that rise-logger checks on ready handler for determining if running in an integration test
+    window.riseLoggerTests = true;
+  </script>
 
   <link rel="import" href="../../rise-data.html">
 </head>
@@ -18,9 +22,9 @@
 <script src="../../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
 
 <script>
-  /* global sinon, suite, test, assert, setup, teardown, sheetKey, sheetData */
+  /* global sinon, suite, suiteSetup, test, assert, setup, teardown, sheetKey, sheetData */
 
-  var dataRequest = document.querySelector( "#request" );
+  var dataRequest = document.querySelector( "#request" ); // eslint-disable-line vars-on-top
 
   // mock logger getting display id and force handler RC not running
   sinon.stub( dataRequest.$.logger.$.displayId, "generateRequest", function() {
@@ -33,6 +37,11 @@
   } );
 
   suite( "localStorage", function() {
+
+    suiteSetup( function() {
+      // required for integration test
+      dataRequest._startTests();
+    } );
 
     suite( "saveItem", function() {
 

--- a/test/unit/rise-data-none-storage-rc-running.html
+++ b/test/unit/rise-data-none-storage-rc-running.html
@@ -7,6 +7,10 @@
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script>
+    // global flag that rise-logger checks on ready handler for determining if running in an integration test
+    window.riseLoggerTests = true;
+  </script>
 
   <link rel="import" href="../../rise-data.html">
 </head>
@@ -21,7 +25,7 @@
 <script>
   /* global sinon, suite, test, assert, suiteSetup, suiteTeardown, setup, teardown, sheetKey, sheetData */
 
-  var dataRequest = document.querySelector( "#request" );
+  var dataRequest = document.querySelector( "#request" ); // eslint-disable-line vars-on-top
 
   // mock logger getting display id and force RC running
   sinon.stub( dataRequest.$.logger.$.displayId, "generateRequest", function() {
@@ -36,6 +40,8 @@
   suite( "sessionStorage when RC is running", function() {
     suiteSetup( function() {
       dataRequest.endpoint = "spreadsheets"
+      // required for integration test
+      dataRequest._startTests();
     } );
 
     suiteTeardown( function() {

--- a/test/unit/rise-data-session-storage-rc-running.html
+++ b/test/unit/rise-data-session-storage-rc-running.html
@@ -7,6 +7,10 @@
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script>
+    // global flag that rise-logger checks on ready handler for determining if running in an integration test
+    window.riseLoggerTests = true;
+  </script>
 
   <link rel="import" href="../../rise-data.html">
 </head>
@@ -20,7 +24,7 @@
 <script>
   /* global sinon, suite, test, assert, suiteSetup, suiteTeardown, setup, teardown, sheetKey, sheetData */
 
-  var dataRequest = document.querySelector( "#request" );
+  var dataRequest = document.querySelector( "#request" ); // eslint-disable-line vars-on-top
 
   // mock logger getting display id and force RC running
   sinon.stub( dataRequest.$.logger.$.displayId, "generateRequest", function() {
@@ -34,7 +38,9 @@
 
   suite( "sessionStorage when RC is running", function() {
     suiteSetup( function() {
-      dataRequest.endpoint = "spreadsheets"
+      dataRequest.endpoint = "spreadsheets";
+      // required for integration test
+      dataRequest._startTests();
     } );
 
     suiteTeardown( function() {

--- a/test/unit/rise-data-session-storage.html
+++ b/test/unit/rise-data-session-storage.html
@@ -7,6 +7,10 @@
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script>
+    // global flag that rise-logger checks on ready handler for determining if running in an integration test
+    window.riseLoggerTests = true;
+  </script>
 
   <link rel="import" href="../../rise-data.html">
 </head>
@@ -18,9 +22,9 @@
 <script src="../../node_modules/widget-tester/mocks/sessionStorage-mock.js"></script>
 
 <script>
-  /* global sinon, suite, test, assert, setup, teardown, sheetKey, sheetData */
+  /* global sinon, suite, suiteSetup, test, assert, setup, teardown, sheetKey, sheetData */
 
-  var dataRequest = document.querySelector( "#request" );
+  var dataRequest = document.querySelector( "#request" ); // eslint-disable-line vars-on-top
 
   // mock logger getting display id and force handler RC not running
   sinon.stub( dataRequest.$.logger.$.displayId, "generateRequest", function() {
@@ -33,6 +37,11 @@
   } );
 
   suite( "sessionStorage", function() {
+
+    suiteSetup( function() {
+      // required for integration test
+      dataRequest._startTests();
+    } );
 
     suite( "saveItem", function() {
 

--- a/test/unit/rise-data.html
+++ b/test/unit/rise-data.html
@@ -7,6 +7,10 @@
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script>
+    // global flag that rise-logger checks on ready handler for determining if running in an integration test
+    window.riseLoggerTests = true;
+  </script>
 
   <link rel="import" href="../../rise-data.html">
 </head>
@@ -18,9 +22,9 @@
 <script src="../../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
 
 <script>
-  /* global sinon, suite, test, assert, setup, teardown */
+  /* global sinon, suite, suiteSetup, test, assert, setup, teardown */
 
-  var dataRequest = document.querySelector( "#request" );
+  var dataRequest = document.querySelector( "#request" ); // eslint-disable-line vars-on-top
 
   // mock logger getting display id and force handler of RC not running
   sinon.stub( dataRequest.$.logger.$.displayId, "generateRequest", function() {
@@ -33,6 +37,11 @@
   } );
 
   suite( "rise-data", function() {
+
+    suiteSetup( function() {
+      // required for integration test
+      dataRequest._startTests();
+    } );
 
     suite( "_isValidUsage", function() {
 
@@ -175,26 +184,23 @@
       } );
 
       test( "should log usage", function() {
-        dataRequest.ready();
+        dataRequest.ready( true );
         assert.equal( logStub.args[ 0 ][ 0 ], "component_data_events" );
         assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"event\":\"ready\",\"version\":" );
       } );
 
       test( "should log usage and include 'usage_type'", function() {
         dataRequest.usage = "widget";
-        dataRequest.ready();
+        dataRequest.ready( true );
         assert.equal( logStub.args[ 0 ][ 0 ], "component_data_events" );
         assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"event\":\"ready\",\"usage_type\":\"widget\",\"version\":" );
       } );
-    } );
-
-    suite( "attached", function() {
 
       test( "should set ping request url to use 'rchttps' scheme", function() {
         sinon.stub( dataRequest, "_isRiseCacheSchemeEnabled", function() {
           return true;
         } );
-        dataRequest.attached();
+        dataRequest.ready( true );
 
         assert.isTrue( dataRequest.$.ping.url.startsWith( "rchttps://" ) );
         dataRequest._isRiseCacheSchemeEnabled.restore();
@@ -204,12 +210,11 @@
         sinon.stub( dataRequest, "_isRiseCacheSchemeEnabled", function() {
           return false;
         } );
-        dataRequest.attached();
+        dataRequest.ready( true );
 
         assert.isTrue( dataRequest.$.ping.url.startsWith( "https://" ) );
         dataRequest._isRiseCacheSchemeEnabled.restore();
       } );
-
     } );
 
   } );


### PR DESCRIPTION
- This is to fix the issue with Spreadsheet widget running in Preview on Chrome 67 whereby `attached` in this component is not firing. 
- Tests required fixing to prevent code from executing before any sinon test stubs could be created